### PR TITLE
Implement HTTP4s endpoints

### DIFF
--- a/src/main/scala/com/reagroup/appliedscala/AppRuntime.scala
+++ b/src/main/scala/com/reagroup/appliedscala/AppRuntime.scala
@@ -55,10 +55,10 @@ class AppRuntime(config: Config, httpClient: Client[IO], contextShift: ContextSh
 
   private val appRoutes = new AppRoutes(
     fetchAllMoviesHandler = fetchAllMoviesController.fetchAll,
-    fetchMovieHandler = (movieId: Long) => fetchMovieController.fetch(movieId),
-    fetchEnrichedMovieHandler = (movieId: Long) => fetchEnrichedMovieController.fetch(movieId),
-    saveMovieHandler = (request: Request[IO]) => saveMovieController.save(request),
-    saveReviewHandler = (movieId: Long, request: Request[IO]) => saveReviewController.save(movieId, request)
+    fetchMovieHandler = fetchMovieController.fetch,
+    fetchEnrichedMovieHandler = fetchEnrichedMovieController.fetch,
+    saveMovieHandler = saveMovieController.save,
+    saveReviewHandler = saveReviewController.save
   )
 
   /*

--- a/src/main/scala/com/reagroup/appliedscala/models/Movie.scala
+++ b/src/main/scala/com/reagroup/appliedscala/models/Movie.scala
@@ -13,4 +13,6 @@ object Movie {
     * Hint: Use `deriveEncoder`
     */
 
+  implicit val movieEncoder: Encoder[Movie] = deriveEncoder
+
 }

--- a/src/main/scala/com/reagroup/appliedscala/models/MovieId.scala
+++ b/src/main/scala/com/reagroup/appliedscala/models/MovieId.scala
@@ -1,7 +1,6 @@
 package com.reagroup.appliedscala.models
 
-import io.circe.Encoder
-import io.circe.Json
+import io.circe.{Decoder, Encoder, Json}
 
 case class MovieId(value: Long)
 
@@ -18,4 +17,12 @@ object MovieId {
     *
     * Hint: You don't want to use `deriveEncoder` here
     */
+
+  implicit val movieIdEncoder: Encoder[MovieId] = (movieId: MovieId) => {
+    Json.obj(
+      ("id", Json.fromLong(movieId.value))
+    )
+  }
+
+  implicit val movieIdDecoder: Decoder[MovieId] = Decoder.decodeLong.map(MovieId(_))
 }

--- a/src/main/scala/com/reagroup/appliedscala/models/Review.scala
+++ b/src/main/scala/com/reagroup/appliedscala/models/Review.scala
@@ -13,4 +13,6 @@ object Review {
     * Hint: Use `deriveEncoder`
     */
 
+  implicit val reviewEncoder: Encoder[Review] = deriveEncoder
+
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/fetchenrichedmovie/EnrichedMovie.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/fetchenrichedmovie/EnrichedMovie.scala
@@ -36,4 +36,13 @@ object EnrichedMovie {
     * Hint: You will need to create a custom encoder (you can use .forProduct).
     */
 
+  implicit val encoder: Encoder[EnrichedMovie] = (enrichedMovie: EnrichedMovie) => {
+    Json.obj(
+      ("name", Json.fromString(enrichedMovie.movie.name)),
+      ("synopsis", Json.fromString(enrichedMovie.movie.synopsis)),
+      ("reviews", enrichedMovie.movie.reviews.asJson),
+      ("metascore", Json.fromInt(enrichedMovie.metascore.value)),
+    )
+  }
+
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/fetchenrichedmovie/FetchEnrichedMovieController.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/fetchenrichedmovie/FetchEnrichedMovieController.scala
@@ -18,12 +18,12 @@ class FetchEnrichedMovieController(fetchEnrichedMovie: MovieId => IO[Option[Enri
     * Hint: Refer to `FetchMovieController` if you're stuck.
     */
   def fetch(movieId: Long): IO[Response[IO]] = {
-    val id: MovieId = ???
+    val id: MovieId = MovieId(movieId)
 
     fetchEnrichedMovie(id).attempt.flatMap {
-      case Left(error) => ???
-      case Right(Some(enrichedMovie)) => ???
-      case Right(None) => ???
+      case Left(error) => ErrorHandler(error)
+      case Right(Some(enrichedMovie)) => Ok(enrichedMovie.asJson)
+      case Right(None) => NotFound()
     }
 
   }

--- a/src/main/scala/com/reagroup/appliedscala/urls/fetchenrichedmovie/FetchEnrichedMovieService.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/fetchenrichedmovie/FetchEnrichedMovieService.scala
@@ -16,12 +16,22 @@ class FetchEnrichedMovieService(fetchMovie: MovieId => IO[Option[Movie]],
     * Hint: We know we are going to be chaining multiple effects in `IO` so let's start a for-comprehension.
     * Also pattern match on `Option` if you're stuck!
     **/
-  def fetch(movieId: MovieId): IO[Option[EnrichedMovie]] = ???
+  def fetch(movieId: MovieId): IO[Option[EnrichedMovie]] = {
+    fetchMovie(movieId).flatMap(_ match {
+      case Some(movie) => enrichMovieWithMetascore(movie).map(Some(_))
+      case None => IO.pure(None)
+    })
+  }
 
   /**
     * Given a `Movie`, we can call `fetchMetascore` using the `name` of the `Movie`.
     * If no `Metascore` is found, raise an `EnrichmentFailure` using `IO.raiseError`.
     **/
-  private def enrichMovieWithMetascore(movie: Movie): IO[EnrichedMovie] = ???
+  private def enrichMovieWithMetascore(movie: Movie): IO[EnrichedMovie] = {
+    fetchMetascore(movie.name).flatMap(maybeMetaScore => maybeMetaScore match {
+      case Some(metascore) => IO.pure(EnrichedMovie(movie, metascore))
+      case None =>IO.raiseError(EnrichmentFailure(movie.name))
+    })
+  }
 
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/fetchenrichedmovie/Metascore.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/fetchenrichedmovie/Metascore.scala
@@ -1,8 +1,9 @@
 package com.reagroup.appliedscala.urls.fetchenrichedmovie
 
+import io.circe.{Decoder, DecodingFailure}
 import io.circe.Decoder.Result
-import io.circe.{Decoder, DecodingFailure, Encoder, HCursor}
-import io.circe.generic.semiauto._
+
+import scala.util.{Failure, Success, Try}
 
 case class Metascore(value: Int)
 
@@ -14,11 +15,11 @@ object Metascore {
     * Convert:
     *
     * {
-    *   ..
-    *   ..
-    *   "Metascore": "75",
-    *   ..
-    *   ..
+    * ..
+    * ..
+    * "Metascore": "75",
+    * ..
+    * ..
     * }
     *
     * into:
@@ -26,4 +27,9 @@ object Metascore {
     * `Metascore(75)`
     */
 
+  implicit val metascoreDecoder: Decoder[Metascore] = cursor => {
+    for {
+      metascore <- cursor.downField("Metascore").as[Int]
+    } yield Metascore(metascore)
+  }
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/fetchmovie/FetchMovieController.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/fetchmovie/FetchMovieController.scala
@@ -19,7 +19,15 @@ class FetchMovieController(fetchMovie: MovieId => IO[Option[Movie]]) extends Htt
     * Hint: You can use `NotFound()` to construct a 404 and `Ok()` to construct a 200.
     * Delegate the error case to the `ErrorHandler`.
     */
-  def fetch(movieId: Long): IO[Response[IO]] =
-    ???
+  def fetch(movieId: Long): IO[Response[IO]] = {
+    val fetchMovieAttempt: IO[Either[Throwable, Option[Movie]]] = fetchMovie(MovieId(movieId)).attempt
 
+    fetchMovieAttempt.flatMap {
+      case Left(error) => ErrorHandler(error)
+      case Right(maybeMovie) => maybeMovie match {
+        case Some(movie) => Ok(movie.asJson)
+        case None => NotFound()
+      }
+    }
+  }
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/fetchmovie/FetchMovieService.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/fetchmovie/FetchMovieService.scala
@@ -11,6 +11,6 @@ class FetchMovieService(fetchMovie: MovieId => IO[Option[Movie]]) {
     * We have a `MovieId` and we want to yield a `IO[Option[Movie]]` and we have precisely the function that can do this for us in scope.
     */
   def fetch(movieId: MovieId): IO[Option[Movie]] =
-    ???
+    fetchMovie(movieId)
 
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/repositories/Http4sMetascoreRepository.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/repositories/Http4sMetascoreRepository.scala
@@ -4,8 +4,8 @@ import cats.effect.IO
 import com.reagroup.appliedscala.urls.fetchenrichedmovie.Metascore
 import io.circe.parser.decode
 import org.http4s._
-import org.http4s.implicits._
 import org.http4s.client.Client
+import org.http4s.implicits._
 
 class Http4sMetascoreRepository(httpClient: Client[IO], apiKey: String) {
 
@@ -18,7 +18,13 @@ class Http4sMetascoreRepository(httpClient: Client[IO], apiKey: String) {
       .withQueryParam("apikey", apiKey)
       .withQueryParam("t", movieName)
     val ioStr: IO[String] = httpClient.expect[String](omdbURI)
-    ???
+    ioStr.attempt.map(maybeJson => maybeJson match {
+      case Left(_) => None
+      case Right(maybeJson) => Some(decode[Metascore](maybeJson) match {
+        case Left(_) => None
+        case Right(value) => Some(value)
+      }).flatten
+    })
   }
 
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/repositories/Http4sMetascoreRepository.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/repositories/Http4sMetascoreRepository.scala
@@ -18,13 +18,8 @@ class Http4sMetascoreRepository(httpClient: Client[IO], apiKey: String) {
       .withQueryParam("apikey", apiKey)
       .withQueryParam("t", movieName)
     val ioStr: IO[String] = httpClient.expect[String](omdbURI)
-    ioStr.attempt.map(maybeJson => maybeJson match {
-      case Left(_) => None
-      case Right(maybeJson) => Some(decode[Metascore](maybeJson) match {
-        case Left(_) => None
-        case Right(value) => Some(value)
-      }).flatten
-    })
+
+    ioStr.map(response => decode[Metascore](response).toOption)
   }
 
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/savemovie/MovieValidationError.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/savemovie/MovieValidationError.scala
@@ -23,7 +23,10 @@ object MovieValidationError {
     * Hint: Use pattern matching
     */
   def show(error: MovieValidationError): String =
-    ???
+    error match {
+      case MovieNameTooShort => "MOVIE_NAME_TOO_SHORT"
+      case MovieSynopsisTooShort => "MOVIE_SYNOPSIS_TOO_SHORT"
+    }
 
   /**
     * Add an Encoder instance here
@@ -36,5 +39,11 @@ object MovieValidationError {
     *
     * Hint: You don't want to use `deriveEncoder` here
     */
+
+  implicit val movieValidationErrorEncoder: Encoder[MovieValidationError] = (movievalidationError: MovieValidationError) => {
+    Json.obj(
+      ("error", show(movievalidationError).asJson)
+    )
+  }
 
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/savemovie/NewMovieRequest.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/savemovie/NewMovieRequest.scala
@@ -18,4 +18,10 @@ object NewMovieRequest {
     * Hint: The keys in the JSON are named exactly the same as the fields in `NewMovieRequest`.
     */
 
+  implicit val newMovieRequestDecoder: Decoder[NewMovieRequest] = cursor => {
+    for {
+      name <- cursor.get[String]("name")
+      synopsis <- cursor.get[String]("synopsis")
+    } yield NewMovieRequest(name, synopsis)
+  }
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/savemovie/NewMovieValidator.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/savemovie/NewMovieValidator.scala
@@ -11,8 +11,14 @@ object NewMovieValidator {
     *
     * Hint: `Validated` has an Applicative instance.
     */
-  def validate(newMovie: NewMovieRequest): ValidatedNel[MovieValidationError, ValidatedMovie] =
-    ???
+  def validate(newMovie: NewMovieRequest): ValidatedNel[MovieValidationError, ValidatedMovie] = {
+    val validatedNameNel = validateMovieName(newMovie.name)
+    val validatedSynopsisNel = validateMovieSynopsis(newMovie.synopsis)
+    (validatedNameNel, validatedSynopsisNel)
+      .mapN(
+        (validatedName, validatedSynposis) => ValidatedMovie(validatedName, validatedSynposis)
+      )
+  }
 
   /**
     * If `name` is empty, return an `InvalidNel` containing `MovieNameTooShort`,
@@ -21,7 +27,11 @@ object NewMovieValidator {
     * Hint: You can use `.isEmpty` or `.nonEmpty` on `String`
     */
   private def validateMovieName(name: String): ValidatedNel[MovieValidationError, String] =
-    ???
+    if (name.isEmpty) {
+      MovieNameTooShort.invalidNel
+    } else {
+      name.validNel
+    }
 
   /**
     * If `synopsis` is empty, return an `InvalidNel` containing `MovieSynopsisTooShort`,
@@ -30,6 +40,10 @@ object NewMovieValidator {
     * Hint: You can use `.isEmpty` or `.nonEmpty` on `String`
     */
   private def validateMovieSynopsis(synopsis: String): ValidatedNel[MovieValidationError, String] =
-    ???
+    if (synopsis.isEmpty) {
+      MovieSynopsisTooShort.invalidNel
+    } else {
+      synopsis.validNel
+    }
 
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/savemovie/SaveMovieController.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/savemovie/SaveMovieController.scala
@@ -1,10 +1,9 @@
 package com.reagroup.appliedscala.urls.savemovie
 
 import cats.data.Validated._
-import cats.data.{NonEmptyList, ValidatedNel}
+import cats.data.ValidatedNel
 import cats.effect.IO
 import com.reagroup.appliedscala.models._
-import io.circe.{Encoder, Json}
 import io.circe.syntax._
 import org.http4s._
 import org.http4s.circe.CirceEntityCodec._
@@ -18,7 +17,17 @@ class SaveMovieController(saveNewMovie: NewMovieRequest => IO[ValidatedNel[Movie
     * 3. Pattern match and convert every case into an HTTP response. To Pattern match on `Validated`, use `Invalid` and `Valid`.
     * Hint: Use `Created(...)` to return a 201 response when the movie is successfully saved and `BadRequest(...)` to return a 403 response when there are errors.
     */
-  def save(req: Request[IO]): IO[Response[IO]] =
-    ???
-
+  def save(req: Request[IO]): IO[Response[IO]] = {
+    val ioNewMovieRequest = req.as[NewMovieRequest]
+    ioNewMovieRequest.flatMap(newMovieRequest => {
+      val saveNewMovieAttempt: IO[Either[Throwable, ValidatedNel[MovieValidationError, MovieId]]] = saveNewMovie(newMovieRequest).attempt
+      saveNewMovieAttempt.flatMap {
+        case Left(_) => BadRequest()
+        case Right(validatedMovieNel) => validatedMovieNel match {
+          case Valid(movieId) => Created(movieId.asJson)
+          case Invalid(errors) => BadRequest(errors.map(_.asJson))
+        }
+      }
+    })
+  }
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/savemovie/SaveMovieService.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/savemovie/SaveMovieService.scala
@@ -10,8 +10,11 @@ class SaveMovieService(saveMovie: ValidatedMovie => IO[MovieId]) {
   /**
     * Before saving a `NewMovieRequest`, we want to validate the request in order to get a `ValidatedMovie`.
     * Complete `NewMovieValidator`, then use it here before calling `saveMovie`.
+    * What on earth is traverse
     */
-  def save(newMovieReq: NewMovieRequest): IO[ValidatedNel[MovieValidationError, MovieId]] =
-    ???
+  def save(newMovieReq: NewMovieRequest): IO[ValidatedNel[MovieValidationError, MovieId]] = {
+    val validatedMovie = NewMovieValidator.validate(newMovieReq)
+    validatedMovie.traverse(saveMovie)
+  }
 
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/savereview/NewReviewValidator.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/savereview/NewReviewValidator.scala
@@ -12,7 +12,9 @@ object NewReviewValidator {
     * Hint: `Validated` has an Applicative instance.
     */
   def validate(review: NewReviewRequest): ValidatedNel[ReviewValidationError, ValidatedReview] =
-    ???
+    (validateAuthor(review.author), validateComment(review.comment)).mapN(
+      (review, comment) => ValidatedReview(review, comment)
+    )
 
   /**
     * If `author` is empty, return an `InvalidNel` containing `ReviewAuthorTooShort`,
@@ -21,7 +23,11 @@ object NewReviewValidator {
     * Hint: You can use `.isEmpty` or `.nonEmpty` on `String`
     */
   private def validateAuthor(author: String): ValidatedNel[ReviewValidationError, String] =
-    ???
+    if (author.isEmpty) {
+      ReviewAuthorTooShort.invalidNel
+    } else {
+      author.validNel
+    }
 
   /**
     * If `comment` is empty, return an `InvalidNel` containing `ReviewCommentTooShort`,
@@ -30,6 +36,10 @@ object NewReviewValidator {
     * Hint: You can use `.isEmpty` or `.nonEmpty` on `String`
     */
   private def validateComment(comment: String): ValidatedNel[ReviewValidationError, String] =
-    ???
+    if(comment.isEmpty) {
+      ReviewCommentTooShort.invalidNel
+    } else {
+      comment.validNel
+    }
 
 }

--- a/src/main/scala/com/reagroup/appliedscala/urls/savereview/SaveReviewService.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/savereview/SaveReviewService.scala
@@ -15,10 +15,21 @@ class SaveReviewService(saveReview: (MovieId, ValidatedReview) => IO[ReviewId],
     * Return all errors encountered whether the movie exists or not.
     *
     */
-  def save(movieId: MovieId, review: NewReviewRequest): IO[ValidatedNel[ReviewValidationError, ReviewId]] = ???
+  def save(movieId: MovieId, review: NewReviewRequest): IO[ValidatedNel[ReviewValidationError, ReviewId]] = {
+    fetchMovie(movieId).flatMap(movieOp => {
+      val validatedMovie = validateMovie(movieOp)
+      val validatedReview = validateReview(review)
+      val combinedValidatedReview = (validatedMovie).productR(validatedReview)
+      combinedValidatedReview.traverse(validatedReview => saveReview(movieId, validatedReview))
+    })
+  }
 
-  private def validateMovie(movieOp: Option[Movie]): ValidatedNel[ReviewValidationError, Movie] = ???
+  private def validateMovie(movieOp: Option[Movie]): ValidatedNel[ReviewValidationError, Movie] = movieOp match {
+    case Some(movie) => movie.validNel
+    case None => MovieDoesNotExist.invalidNel
+  }
 
-  private def validateReview(review: NewReviewRequest): ValidatedNel[ReviewValidationError, ValidatedReview] = ???
+  private def validateReview(review: NewReviewRequest): ValidatedNel[ReviewValidationError, ValidatedReview] =
+    NewReviewValidator.validate(review)
 
 }

--- a/src/test/scala/com/reagroup/appliedscala/AppRoutesSpec.scala
+++ b/src/test/scala/com/reagroup/appliedscala/AppRoutesSpec.scala
@@ -23,9 +23,9 @@ class AppRoutesSpec extends Specification with Http4sDsl[IO] with Http4sMatchers
   private val testAppRoutes = new AppRoutes(
     fetchAllMoviesHandler = fetchAllMovies,
     saveMovieHandler = saveMovie,
-//    fetchMovieHandler = fetchMovie,
-//    fetchEnrichedMovieHandler = fetchEnrichedMovie,
-//    saveReviewHandler = saveReview
+    fetchMovieHandler = fetchMovie,
+    fetchEnrichedMovieHandler = fetchEnrichedMovie,
+    saveReviewHandler = saveReview
   )
 
   /*


### PR DESCRIPTION
# Key learnings
- Http4s: https://http4s.org/v0.21/
- Http4s Handlers return `IO[Response[IO]]` 
  - https://github.com/realestate-com-au/applied-scala/blob/solutions-20200728/docs/faq.md#http4s-types (TL;DR: "outer" IO: effects to decide how to respond. "inner" IO: effects to produce the response stream.)
- Structure:
  - Repository (data source)
  - Service (utilises injected repository to perform action, usually returns `IO[Something]`)
  - Controller  (utilises injected service, usually do `.attempt` here, returns `IO[Response[IO]`)
  - AppRuntime (where you instantiate repository, service, controller)
  - AppRoutes (`HttpRoutes`), each route maps to a controller